### PR TITLE
Add support for importing non-TeX files with slash-input

### DIFF
--- a/xpandlatex
+++ b/xpandlatex
@@ -820,7 +820,12 @@ class XpandLaTeX:
         # get the filename
         tok = self.get_token('parsing')
         if not tok == '{': self.die(r'\input: unexpected token <' + tok + '>')
-        file = ''.join(self.get_tokens_to_match(['}'])) + ".tex"
+        file = ''.join(self.get_tokens_to_match(['}']))
+
+        # Allow input of non-tex files, but still default with tex
+        # This could be done better with pathlib
+        if file[-4] != '.':
+            file += '.tex'
 
         file_xpander = XpandLaTeX(copy=self)
         file_xpander.process_file(file)


### PR DESCRIPTION
I have a file where I need to input another file's *.toc, but the current input method of xpandlatex kept me from that. With this correction, it checks for an 3 letter extension, and if there isn't one, it appends the .tex extension. This could be done better with pathlib, and some library of file types, and checking for the existence of a file, but this is the time I have right now.